### PR TITLE
Use Python 3.9.16 on Cygwin CI

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v4
       with:
-        packages: python38 python38-pip python38-virtualenv git
+        packages: python39=3.9.16-1 python39-pip=23.0.1-1 python39-virtualenv git
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
@@ -55,23 +55,18 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Update PyPA packages
-      run: |
-        # Get the latest pip, setuptools, and wheel.
-        python3.8 -m pip install -U pip setuptools wheel
-
     - name: Install project and test dependencies
       run: |
-        python3.8 -m pip install ".[test]"
+        python3.9 -m pip install ".[test]"
 
     - name: Show version and platform information
       run: |
         uname -a
-        command -v git python3.8
+        command -v git python3.9
         git version
-        python3.8 --version
-        python3.8 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+        python3.9 --version
+        python3.9 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |
-        python3.8 -m pytest --color=yes -p no:sugar --instafail -vv
+        python3.9 -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39=3.9.16-1 python39-pip=23.0.1-1 python39-virtualenv git
+        packages: python39 python39-pip python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     defaults:
       run:
-        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
 
     steps:
     - name: Force LF line endings
@@ -27,11 +27,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Cygwin
-      uses: cygwin/cygwin-install-action@v4
+    - name: Set up Cygwin
+      uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39=3.9.16-1 python39-pip=23.0.1-1 python39-virtualenv git
-        add-to-path: false  # No need to change $PATH outside the Cygwin environment.
+        packages: python38 python38-pip python38-virtualenv git
 
     - name: Arrange for verbose output
       run: |
@@ -55,18 +54,23 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
+    - name: Update PyPA packages
+      run: |
+        # Get the latest pip, setuptools, and wheel.
+        python3.8 -m pip install -U pip setuptools wheel
+
     - name: Install project and test dependencies
       run: |
-        python3.9 -m pip install ".[test]"
+        python3.8 -m pip install ".[test]"
 
     - name: Show version and platform information
       run: |
         uname -a
-        command -v git python3.9
+        command -v git python3.8
         git version
-        python3.9 --version
-        python3.9 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+        python3.8 --version
+        python3.8 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |
-        python3.9 -m pytest --color=yes -p no:sugar --instafail -vv
+        python3.8 -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39 python39-pip=23.0.1-1 python39-virtualenv git
+        packages: python39=3.9.16-1 python39-pip python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39 python39-pip python39-virtualenv git
+        packages: python39 python39-pip=23.0.1-1 python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     defaults:
       run:
-        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
 
     steps:
     - name: Force LF line endings
@@ -27,11 +27,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Cygwin
-      uses: cygwin/cygwin-install-action@v4
+    - name: Set up Cygwin
+      uses: egor-tensin/setup-cygwin@v4
       with:
         packages: python39=3.9.16-1 python39-pip python39-virtualenv git
-        add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python38 python38-pip python38-virtualenv git
+        packages: python39 python39-pip python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |
@@ -57,20 +57,20 @@ jobs:
     - name: Update PyPA packages
       run: |
         # Get the latest pip, setuptools, and wheel.
-        python3.8 -m pip install -U pip setuptools wheel
+        python3.9 -m pip install -U pip setuptools wheel
 
     - name: Install project and test dependencies
       run: |
-        python3.8 -m pip install ".[test]"
+        python3.9 -m pip install ".[test]"
 
     - name: Show version and platform information
       run: |
         uname -a
-        command -v git python3.8
+        command -v git python3.9
         git version
-        python3.8 --version
-        python3.8 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+        python3.9 --version
+        python3.9 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |
-        python3.8 -m pytest --color=yes -p no:sugar --instafail -vv
+        python3.9 -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v4
       with:
-        packages: python39 python39-pip python39-virtualenv git
+        packages: python38 python38-pip python38-virtualenv git
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
@@ -58,20 +58,20 @@ jobs:
     - name: Update PyPA packages
       run: |
         # Get the latest pip, setuptools, and wheel.
-        python3.9 -m pip install -U pip setuptools wheel
+        python3.8 -m pip install -U pip setuptools wheel
 
     - name: Install project and test dependencies
       run: |
-        python3.9 -m pip install ".[test]"
+        python3.8 -m pip install ".[test]"
 
     - name: Show version and platform information
       run: |
         uname -a
-        command -v git python3.9
+        command -v git python3.8
         git version
-        python3.9 --version
-        python3.9 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+        python3.8 --version
+        python3.8 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |
-        python3.9 -m pytest --color=yes -p no:sugar --instafail -vv
+        python3.8 -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -54,6 +54,11 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
+    - name: Update PyPA packages
+      run: |
+        # Get the latest pip, setuptools, and wheel.
+        python3.9 -m pip install -U pip setuptools wheel
+
     - name: Install project and test dependencies
       run: |
         python3.9 -m pip install ".[test]"

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v4
       with:
-        packages: python38 python38-pip python38-virtualenv git
+        packages: python39 python39-pip python39-virtualenv git
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
@@ -58,20 +58,20 @@ jobs:
     - name: Update PyPA packages
       run: |
         # Get the latest pip, setuptools, and wheel.
-        python3.8 -m pip install -U pip setuptools wheel
+        python3.9 -m pip install -U pip setuptools wheel
 
     - name: Install project and test dependencies
       run: |
-        python3.8 -m pip install ".[test]"
+        python3.9 -m pip install ".[test]"
 
     - name: Show version and platform information
       run: |
         uname -a
-        command -v git python3.8
+        command -v git python3.9
         git version
-        python3.8 --version
-        python3.8 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+        python3.9 --version
+        python3.9 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |
-        python3.8 -m pytest --color=yes -p no:sugar --instafail -vv
+        python3.9 -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39 python39-pip python39-virtualenv git
+        packages: python39=3.9.16-1 python39-pip=23.0.1-1 python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |
@@ -53,11 +53,6 @@ jobs:
         # If we rewrite the user's config by accident, we will mess it up
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
-
-    - name: Update PyPA packages
-      run: |
-        # Get the latest pip, setuptools, and wheel.
-        python3.9 -m pip install -U pip setuptools wheel
 
     - name: Install project and test dependencies
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     defaults:
       run:
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
 
     steps:
     - name: Force LF line endings
@@ -27,10 +27,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Cygwin
-      uses: egor-tensin/setup-cygwin@v4
+    - name: Install Cygwin
+      uses: cygwin/cygwin-install-action@v4
       with:
         packages: python39=3.9.16-1 python39-pip python39-virtualenv git
+        add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
       run: |
@@ -54,23 +55,28 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
+    - name: Ensure the "pip" command is available
+      run: |
+        # This is used unless, and before, an updated pip is installed.
+        ln -s pip3 /usr/bin/pip
+
     - name: Update PyPA packages
       run: |
-        # Get the latest pip, setuptools, and wheel.
-        python3.9 -m pip install -U pip setuptools wheel
+        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
-        python3.9 -m pip install ".[test]"
+        pip install ".[test]"
 
     - name: Show version and platform information
       run: |
         uname -a
-        command -v git python3.9
+        command -v git python
         git version
-        python3.9 --version
-        python3.9 -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+        python --version
+        python -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |
-        python3.9 -m pytest --color=yes -p no:sugar --instafail -vv
+        pytest --color=yes -p no:sugar --instafail -vv


### PR DESCRIPTION
The latest currently packaged version of Python 3.9 for Cygwin is 3.9.18 (provided by the Cygwin package python39 at version 3.9.18-1). That version, at least as we are using it, has a problem where pip has begun to block on some PyPI package downloads.

In 73ebcfa (EliahKagan#2), I worked around this problem by downgrading the minor version of Python to 3.8. But it is better to use 3.9 if we can, since it is currently the latest minor version of Python in the Cygwin repositories, and also because (relating to that) it is used more often, and thus probably used more often with GitPython, than 3.8.

This upgrades Python on Cygwin but not all the way. It upgrades it to the latest (or latest currently available) patch version of 3.9 packaged for Cygwin of those that strictly precede 3.9.18 where the problem occurs. That version is 3.9.16, provided by the Cygwin package python39 at version 3.9.16-1.

This version may eventually no longer be available for download from Cygwin's repositories, so hopefully a real solution or better workaround will be found by then, or perhaps a future update to the package itself will fix the problem.